### PR TITLE
Fixed doctests around 'assigned'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,8 +114,8 @@ certain attributes to the wrapped function for you, namely ``__doc__`` and
 
 The optional ``assigned`` keyword argument can be used to specify which
 attributes of the original function are assigned directly to the matching
-attributes on the wrapper function. This defaults to
-``functools.WRAPPER_ASSIGNMENTS``. You can specify ``False`` or ``None``
+attributes on the wrapper function. This defaults to ``('__doc__',
+-'__name__')``. You can specify ``False`` or ``None`` to disable this.
 to disable this.
 
 .. code:: pycon

--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ certain attributes to the wrapped function for you, namely ``__doc__`` and
 The optional ``assigned`` keyword argument can be used to specify which
 attributes of the original function are assigned directly to the matching
 attributes on the wrapper function. This defaults to ``('__doc__',
--'__name__')``. You can specify ``False`` or ``None`` to disable this.
+'__name__')``. You can specify ``False`` or ``None`` to disable this.
 to disable this.
 
 .. code:: pycon

--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,6 @@ The optional ``assigned`` keyword argument can be used to specify which
 attributes of the original function are assigned directly to the matching
 attributes on the wrapper function. This defaults to ``('__doc__',
 '__name__')``. You can specify ``False`` or ``None`` to disable this.
-to disable this.
 
 .. code:: pycon
 

--- a/README.rst
+++ b/README.rst
@@ -118,15 +118,9 @@ attributes on the wrapper function. This defaults to
 ``functools.WRAPPER_ASSIGNMENTS``. You can specify ``False`` or ``None``
 to disable this.
 
-Also the optional ``updated`` keyword argument can be used to specify which
-attributes of the decorator are updated with the corresponding attributes from
-the original function. This defaults to ``functools.WRAPPER_UPDATES``.
-You can specify ``False`` or ``None`` to disable this.
-
-
 .. code:: pycon
 
-   >>> @identity(assigned=None, updated=None)
+   >>> @identity(assigned=None)
    ... def my_function():
    ...     """My function's docstring."""
    >>> print(my_function.__name__)

--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ to disable this.
    >>> @identity(assigned=None)
    ... def my_function():
    ...     """My function's docstring."""
-   >>> print(my_function.__name__)
-   identity
-   >>> print(my_function.__doc__)
-   Noop decorator: does nothing!
+   >>> my_function.__name__ is None
+   True
+   >>> my_function.__doc__ is None
+   True

--- a/README.rst
+++ b/README.rst
@@ -112,16 +112,24 @@ certain attributes to the wrapped function for you, namely ``__doc__`` and
    >>> print(my_function.__doc__)
    My function's docstring.
 
-The optional ``assigned`` keyword argument can be used to to specify which
+The optional ``assigned`` keyword argument can be used to specify which
 attributes of the original function are assigned directly to the matching
-attributes on the wrapper function. This defaults to ``('__doc__',
-'__name__')``. You can specify ``False`` or ``None`` to disable this.
+attributes on the wrapper function. This defaults to
+``functools.WRAPPER_ASSIGNMENTS``. You can specify ``False`` or ``None``
+to disable this.
+
+Also the optional ``updated`` keyword argument can be used to specify which
+attributes of the decorator are updated with the corresponding attributes from
+the original function. This defaults to ``functools.WRAPPER_UPDATES``.
+You can specify ``False`` or ``None`` to disable this.
+
 
 .. code:: pycon
 
-   >>> @identity(assigned=None)
+   >>> @identity(assigned=None, updated=None)
    ... def my_function():
    ...     """My function's docstring."""
-
    >>> print(my_function.__name__)
+   identity
    >>> print(my_function.__doc__)
+   Noop decorator: does nothing!

--- a/decorum/decorum.py
+++ b/decorum/decorum.py
@@ -19,7 +19,7 @@ class Decorum(object):
 
         """
         #: Function name. Can be overriden with decorated function name,
-        #: depending on values of :py:attr:`assigned` or :attr:`updated`.
+        #: depending on values of :py:attr:`assigned`.
         self.__name__ = self.__class__.__name__
 
         #: Specify which attributes of the original function are assigned
@@ -27,11 +27,6 @@ class Decorum(object):
         self.assigned = functools.WRAPPER_ASSIGNMENTS
         if 'assigned' in kwargs:
             self.assigned = kwargs['assigned']
-        #: Specify which attributes of the decorator are updated with the
-        #: corresponding attributes from the original function.
-        self.updated = functools.WRAPPER_UPDATES
-        if 'updated' in kwargs:
-            self.updated = kwargs['updated']
 
         if args and callable(args[0]):
             # used as decorator without being called
@@ -59,10 +54,7 @@ class Decorum(object):
 
     def wraps(self, f):
         """Wraps the function and returns it"""
-        functools.update_wrapper(self,
-                                 f,
-                                 self.assigned or (),
-                                 self.updated or ())
+        functools.update_wrapper(self, f, self.assigned or (), ())
         return self
 
     def init(self, *args, **kwargs):

--- a/decorum/decorum.py
+++ b/decorum/decorum.py
@@ -12,7 +12,7 @@ class Decorum(object):
 
         >>> decor = Decorum()
         >>> decor.assigned
-        ('__module__', '__name__', '__doc__')
+        ('__doc__', '__name__')
         >>> decor = Decorum(assigned=None)
         >>> bool(decor.assigned)
         False
@@ -24,7 +24,7 @@ class Decorum(object):
 
         #: Specify which attributes of the original function are assigned
         #: directly to the matching attributes on the decorator.
-        self.assigned = functools.WRAPPER_ASSIGNMENTS
+        self.assigned = ('__doc__', '__name__')
         if 'assigned' in kwargs:
             self.assigned = kwargs['assigned']
 
@@ -67,7 +67,7 @@ def decorator(cls):
         def __init__(self, *args, **kwargs):
             Decorum.__init__(self, *args, **kwargs)
             if not self.assigned or '__name__' not in self.assigned:
-                self.__name__ = cls.__name__
+                self.__name__ = None
             if not self.assigned or '__doc__' not in self.assigned:
-                self.__doc__ = cls.__doc__
+                self.__doc__ = None
     return decorated

--- a/tests/doctests.py
+++ b/tests/doctests.py
@@ -1,10 +1,8 @@
-import os
-
 import doctest
 
-here = os.path.dirname(os.path.abspath(__file__))
-project_dir = os.path.dirname(here)
 
-
-def test_doctests():
-    doctest.testfile('../README.rst')
+def test_readme():
+    """README contains doctests, they all pass."""
+    result = doctest.testfile('../README.rst')
+    assert result.attempted != 0
+    assert result.failed == 0


### PR DESCRIPTION
This pull-requests is based on https://github.com/zeekay/decorum/pull/15.
In https://github.com/zeekay/decorum/pull/15, "build fails if doctests fail", but doctests actually fail.
Here, I added a fix for the doctests, but I'm not sure about the implementation.
So you may accept one pull-request but not the other...

Here, I did a change in the behaviour of the `assigned` feature. Check changes in README:

* default value for `assigned` is now `functools.WRAPPER_ASSIGNMENTS`, see https://docs.python.org/2.7/library/functools.html#functools.update_wrapper. It adds `__module__` to the default value. I think it is good to be consistent with Python's standard library. That said, **I can restore the former default if you like**, and create a new pull-request/discussion for this change. Just tell me ;)
* is `assigned` is None, then `__name__` and `__doc__` of the decorated object are the ones of the decorator class, i.e. `identity` and `Noop decorator: does nothing!` instead of `None` and `None`. I think it is more consistent... That said, again, **I can restore the former behaviour**, and perhaps ask for this change in a new pull-request/discussion. Just tell me ;)

What's important here is that doctests are fixed!