### PR TITLE
If 'assigned' is None or False, preserve attributes of original decorator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ disable this.
    >>> @identity(assigned=None)
    ... def my_function():
    ...     """My function's docstring."""
-   >>> my_function.__name__ is None
-   True
-   >>> my_function.__doc__ is None
-   True
+   >>> print(my_function.__name__)
+   identity
+   >>> print(my_function.__doc__)
+   Noop decorator: does nothing!

--- a/decorum/decorum.py
+++ b/decorum/decorum.py
@@ -66,8 +66,10 @@ def decorator(cls):
     class decorated(cls, Decorum):
         def __init__(self, *args, **kwargs):
             Decorum.__init__(self, *args, **kwargs)
-            if not self.assigned or '__name__' not in self.assigned:
-                self.__name__ = None
-            if not self.assigned or '__doc__' not in self.assigned:
-                self.__doc__ = None
+            for attribute in functools.WRAPPER_ASSIGNMENTS:
+                if not self.assigned or attribute not in self.assigned:
+                    try:
+                        setattr(self, attribute, getattr(cls, attribute))
+                    except AttributeError:
+                        pass
     return decorated


### PR DESCRIPTION
Following #16, here is a pull-request about behaviour of "assigned=None" feature.
Implements proposal of #19.