### PR TITLE
Introduce customizable Decorum.call()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Typical usage looks like this:
    >>> class my_decorator(Decorum):
    ...    def wraps(self, f):
    ...        print("I'm returning the function! You can keep it!")
-   ...        return f
+   ...        return super(my_decorator, self).wraps(f)
 
 Decorum lets you write decorators with and without arguments in a unified way.
 Your decorator can be used with or without arguments, called or not, and it
@@ -48,15 +48,14 @@ Writing decorators
 ==================
 
 In order to write your own decorators, just subclass ``decorum.Decorum``.
-There are only two methods to be aware of:
 
-* override ``wraps()`` method to handle the actual decoration and return the
-  decorated function;
+There are only three methods to be aware of when writing your own decorators:
 
-* optionally define an ``init`` method to handle any arguments you want to
-  accept, and handle basic setup (it's called before decoration by
-  ``__init__``, you can use it in a similar fashion to a real ``__init__``
-  method).
+* ``init()`` setups the decorator itself;
+
+* ``wraps()`` decorates the function;
+
+* ``call()`` runs the wrapped function and returns result.
 
 Here is a slightly fancier example:
 
@@ -66,30 +65,33 @@ Here is a slightly fancier example:
 
    >>> class fancy(Decorum):
    ...     def init(self, arg=None):
+   ...         super(fancy, self).init()
    ...         self.arg = arg
    ...
    ...     def wraps(self, f):
    ...         if self.arg:
-   ...             def newf():
-   ...                 print(self.arg)
+   ...             newf = lambda: self.arg
    ...         else:
-   ...             def newf():
-   ...                 print('wut')
-   ...         return newf
+   ...             newf = lambda: 'wut'
+   ...         return super(fancy, self).wraps(newf)
+   ...
+   ...     def call(self, *args, **kwargs):
+   ...         result = super(fancy, self).call(*args, **kwargs)
+   ...         return result.upper()
 
    >>> @fancy
    ... def foo():
    ...     pass
 
    >>> foo()
-   wut
+   'WUT'
 
    >>> @fancy('woof')
    ... def foo():
    ...     pass
 
    >>> foo()
-   woof
+   'WOOF'
 
 .. note::
 

--- a/decorum/decorum.py
+++ b/decorum/decorum.py
@@ -18,6 +18,9 @@ class Decorum(object):
         False
 
         """
+        #: Wrapped function.
+        self._wrapped = None
+
         #: Function name. Can be overriden with decorated function name,
         #: depending on values of :py:attr:`assigned`.
         self.__name__ = self.__class__.__name__
@@ -26,40 +29,40 @@ class Decorum(object):
         #: directly to the matching attributes on the decorator.
         self.assigned = functools.WRAPPER_ASSIGNMENTS
         if 'assigned' in kwargs:
-            self.assigned = kwargs['assigned']
+            self.assigned = kwargs.pop('assigned')
 
         if args and callable(args[0]):
             # used as decorator without being called
             self.init()
-            self._wrapped = self.__call__(args[0])
+            self.wraps(args[0])
         else:
             # used as decorator and called
             self.init(*args, **kwargs)
 
-    def __call__(self, f=None, *args, **kwargs):
+    def __call__(self, *args, **kwargs):
         """Actually run the decorated function.
 
         Uses :meth:`wrap` to handle decoration. Restores :attr:`__doc__` and
         :attr:`__name__`.
 
         """
-        if not callable(f):
-            if f:
-                return self._wrapped(f, *args, **kwargs)
-            else:
-                return self._wrapped(*args, **kwargs)
+        if self._wrapped:
+            return self.call(*args, **kwargs)
         else:
-            wrapped = self.wraps(f)
-            return wrapped
+            f = args[0]
+            return self.wraps(f)
 
     def wraps(self, f):
         """Wraps the function and returns it"""
+        self._wrapped = f
         functools.update_wrapper(self, f, self.assigned or (), ())
         return self
 
-    def init(self, *args, **kwargs):
+    def init(self):
         """Passed any possible arguments to decorator"""
-        pass
+
+    def call(self, *args, **kwargs):
+        return self._wrapped(*args, **kwargs)
 
 
 def decorator(cls):


### PR DESCRIPTION
Refs #23. The `call()` method makes it easy to pre-process input arguments or post-process results.