### PR TITLE
Setup 'assigned' option in 'init' (was in '__init__')

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,8 +64,8 @@ Here is a slightly fancier example:
    >>> from decorum import Decorum
 
    >>> class fancy(Decorum):
-   ...     def init(self, arg=None):
-   ...         super(fancy, self).init()
+   ...     def init(self, arg=None, *args, **kwargs):
+   ...         super(fancy, self).init(*args, **kwargs)
    ...         self.arg = arg
    ...
    ...     def wraps(self, f):

--- a/decorum/decorum.py
+++ b/decorum/decorum.py
@@ -28,8 +28,6 @@ class Decorum(object):
         #: Specify which attributes of the original function are assigned
         #: directly to the matching attributes on the decorator.
         self.assigned = functools.WRAPPER_ASSIGNMENTS
-        if 'assigned' in kwargs:
-            self.assigned = kwargs.pop('assigned')
 
         if args and callable(args[0]):
             # used as decorator without being called
@@ -58,8 +56,9 @@ class Decorum(object):
         functools.update_wrapper(self, f, self.assigned or (), ())
         return self
 
-    def init(self):
+    def init(self, assigned=functools.WRAPPER_ASSIGNMENTS):
         """Passed any possible arguments to decorator"""
+        self.assigned = assigned
 
     def call(self, *args, **kwargs):
         return self._wrapped(*args, **kwargs)


### PR DESCRIPTION
Refs #26.
It changes the way we have to call `super(subclass, self).init()` => we have to pass arguments to parent class.