### PR TITLE
Implement __get__ to allow instance methods to be decorated

### DIFF
--- a/decorum/decorum.py
+++ b/decorum/decorum.py
@@ -45,6 +45,10 @@ class Decorum(object):
         else:
             return self.wraps(args[0])
 
+    def __get__(self, instance, owner):
+        """Allows a decorator to decorate an instance method."""
+        return functools.partial(self.call, instance)
+
     def wraps(self, f):
         """Wraps the function and returns it"""
         self._wrapped = f


### PR DESCRIPTION
Previously, if you decorated a method like so:

```
class MyDecorator(Decorum):
    ...

class A:
    @MyDecorator
    def foo(self, x):
        ...

a = A()
a.foo("bar")
```
... it would fail, because `x` would be passed to `self` when `foo` was called by the decorator. By overriding the `__get__` method, we can keep the original instance (`a`) in the partial function returned. This works with both decorated instance methods and naked methods.